### PR TITLE
Correct parameter name

### DIFF
--- a/mapping-table.txt
+++ b/mapping-table.txt
@@ -15,7 +15,7 @@
    | unit                 | enumeration |32807 | 0 unsigned    | String |
    | unit-status          | boolean     |32808 | 7 bits 20     | False  |
    |                      |             |      | 7 bits 21     | True   |
-   | total-pipe-capability| list        |32809 | 4 array       | Array  |
+   | total-pipe-capacity  | list        |32809 | 4 array       | Array  |
    | link-id              | string      |32810 | 3 text string | String |
    | pre-or-ongoing-      | list        |32811 | 4 array       | Array  |
    |      mitigation      |             |      |               |        |


### PR DESCRIPTION
`total-pipe-capacity` is proper name for `total-pipe-capability`.